### PR TITLE
Register the content of request body to a `REQ_BODY` environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ log_level: "INFO"
 always_mitm: true
 
 routes:
-  # if the request URL is "https://example.com/user/[user_id]/post/[post_id]",
+  # If the request URL is "https://example.com/user/[user_id]/post/[post_id]",
   # reverse proxy to "https://example.com/api?user=[user_id]&post=[post_id]".
   - url: "https://example.com/user/[^/]+/post/[^/]"
     regex: true
@@ -88,7 +88,7 @@ routes:
         from: '^https://example\\.com/user/([^/]+)/post/([^/]+)'
         to: "https://example.com/api?user=$1&post=$2"
         regex: true
-  # if the request URL is "https://example.com/not-found",
+  # If the request URL is "https://example.com/not-found",
   # return the content "not found" with 404 status code.
   - url: "https://example.com/not-found"
     regex: false
@@ -96,13 +96,13 @@ routes:
       content: "not found"
       content_type: "text/plain"
       status: 404
-  # if the request URL is "https://example.com/[any character].png",
+  # If the request URL is "https://example.com/[any character].png",
   # return the file: "./sample.png"
   - url: 'https://example.com/.*\.png'
     regex: true
     response:
       file: "sample.png"
-  # if the request URL is "https://example.com/proxy",
+  # If the request URL is "https://example.com/proxy",
   # reverse proxy to "https://example.com/api" using a specific proxy.
   - url: "https://example.com/proxy"
     regex: false
@@ -112,21 +112,27 @@ routes:
         to: "https://example.com/api"
         regex: false
         proxy: "http://proxy.example.com"
-  # if the request URL is "https://content.test",
-  # return the content "basic" with a custom header.
+  # If the request URL is "https://content.test",
+  # return the content "content XD" with a custom header.
   - url: "https://content.test"
     regex: false
     response:
-      content: "basic"
+      content: "content XD"
       headers:
         "Access-Control-Allow-Origin": "*"
-  # if the request URL is "https://content.test/",
-  # return the content "foo" transformed to "bar".
+  # If the request URL is "https://content.test/",
+  # transform the response body "foo" to "bar" using a sed command.
   - url: "https://content.test/"
     regex: false
     response:
-      content: "foo"
       transform: "sed -E 's/foo/bar/g'"
+  # If the request URL is "https://content.test/",
+  # log both the response content and request body to separate files.
+  # (the `REQ_BODY` environment variable will contain the request body)
+  - url: "https://content.test/"
+    regex: false
+    response:
+      transform: "bash -c 'tee -a ./response.txt ; echo $REQ_BODY >> ./request.txt';"
 ```
 
 ## Certificates

--- a/integration_test/sse_test/sse_test.go
+++ b/integration_test/sse_test/sse_test.go
@@ -1,10 +1,8 @@
 package test
 
 import (
-	"bufio"
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -58,7 +56,7 @@ func TestSSEWithoutProxy(t *testing.T) {
 	assert.NoError(t, err)
 	defer res.Body.Close()
 
-	testSSEStreams(t, res.Body)
+	test_utils.TestSSEStreams(t, res.Body, false)
 }
 
 // test SSE communication with proxy but without rewrite
@@ -67,7 +65,7 @@ func TestSSEWithProxyWithoutRewrite(t *testing.T) {
 	assert.NoError(t, err)
 	defer res.Body.Close()
 
-	testSSEStreams(t, res.Body)
+	test_utils.TestSSEStreams(t, res.Body, false)
 }
 
 // test SSE communication with proxy and with rewrite
@@ -76,30 +74,14 @@ func TestSSEWithProxy(t *testing.T) {
 	assert.NoError(t, err)
 	defer res.Body.Close()
 
-	testSSEStreams(t, res.Body)
+	test_utils.TestSSEStreams(t, res.Body, false)
 }
 
-func testSSEStreams(t *testing.T, body io.ReadCloser) {
-	expectedOutput := []string{
-		"data: SSE message 0\n\n",
-		"data: SSE message 0\n\ndata: SSE message 1\n\n",
-		"data: SSE message 0\n\ndata: SSE message 1\n\ndata: SSE message 2\n\n",
-		"data: SSE message 0\n\ndata: SSE message 1\n\ndata: SSE message 2\n\ndata: SSE message 3\n\n",
-		"data: SSE message 0\n\ndata: SSE message 1\n\ndata: SSE message 2\n\ndata: SSE message 3\n\ndata: SSE message 4\n\n",
-	}
+// test SSE communication with proxy and with rewrite and transform commands
+func TestSSEWithTransform(t *testing.T) {
+	res, err := test_utils.Request(PROXY_URL, "http://sample-sse.test/sse-with-transform")
+	require.NoError(t, err)
+	defer res.Body.Close()
 
-	output := ""
-	go func() {
-		scanner := bufio.NewScanner(body)
-		for scanner.Scan() {
-			line := scanner.Text()
-			output += line + "\n"
-		}
-	}()
-
-	time.Sleep(test_utils.SSE_DURATION / 2)
-	for i := 0; i < 5; i++ {
-		require.Equal(t, expectedOutput[i], output)
-		time.Sleep(test_utils.SSE_DURATION)
-	}
+	test_utils.TestSSEStreams(t, res.Body, true)
 }

--- a/integration_test/sse_test/sse_test.go
+++ b/integration_test/sse_test/sse_test.go
@@ -4,10 +4,10 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -15,6 +15,7 @@ import (
 	"github.com/kajikentaro/flexy-proxy/loggers"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var PROXY_PORT_NUMBER = 8091
@@ -42,71 +43,63 @@ func TestMain(m *testing.M) {
 	// setup proxy server
 	{
 		ctx, cancel := context.WithCancel(context.Background())
-		test_utils.StartProxyServer(ctx, PROXY_HTTP_ADDRESS, "sse_test.yaml")
+		err := test_utils.StartProxyServer(ctx, PROXY_HTTP_ADDRESS, "sse_test.yaml")
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "failed to start a proxy server:", err)
+			os.Exit(1)
+		}
 		defer cancel()
 	}
 	m.Run()
 }
 
 func TestSSEWithoutProxy(t *testing.T) {
-	start := time.Now()
 	res, err := http.Get(SAMPLE_SERVER_URL + "/sse")
 	assert.NoError(t, err)
 	defer res.Body.Close()
 
-	scanner := bufio.NewScanner(res.Body)
-	for scanner.Scan() {
-		line := scanner.Text()
-
-		duration := time.Since(start)
-		assert.Less(t, duration, SSE_TIMEOUT_DURATION)
-		assert.True(t, strings.Contains(line, "data: SSE message") || line == "", "unexpected line: %s", line)
-
-		start = time.Now()
-	}
-	assert.NoError(t, scanner.Err())
+	testSSEStreams(t, res.Body)
 }
 
 // test SSE communication with proxy but without rewrite
 func TestSSEWithProxyWithoutRewrite(t *testing.T) {
-
-	start := time.Now()
 	res, err := test_utils.Request(PROXY_URL, "http://localhost:8092/sse")
 	assert.NoError(t, err)
 	defer res.Body.Close()
 
-	scanner := bufio.NewScanner(res.Body)
-	for scanner.Scan() {
-		line := scanner.Text()
-
-		duration := time.Since(start)
-		assert.Less(t, duration, SSE_TIMEOUT_DURATION)
-		assert.True(t, strings.Contains(line, "data: SSE message") || line == "", "unexpected line: %s", line)
-
-		start = time.Now()
-	}
-	assert.NoError(t, scanner.Err())
-
+	testSSEStreams(t, res.Body)
 }
 
 // test SSE communication with proxy and with rewrite
 func TestSSEWithProxy(t *testing.T) {
-	{
-		start := time.Now()
-		res, err := test_utils.Request(PROXY_URL, "http://sample-sse.test/sse")
-		assert.NoError(t, err)
-		defer res.Body.Close()
+	res, err := test_utils.Request(PROXY_URL, "http://sample-sse.test/sse")
+	assert.NoError(t, err)
+	defer res.Body.Close()
 
-		scanner := bufio.NewScanner(res.Body)
+	testSSEStreams(t, res.Body)
+}
+
+func testSSEStreams(t *testing.T, body io.ReadCloser) {
+	expectedOutput := []string{
+		"data: SSE message 0\n\n",
+		"data: SSE message 0\n\ndata: SSE message 1\n\n",
+		"data: SSE message 0\n\ndata: SSE message 1\n\ndata: SSE message 2\n\n",
+		"data: SSE message 0\n\ndata: SSE message 1\n\ndata: SSE message 2\n\ndata: SSE message 3\n\n",
+		"data: SSE message 0\n\ndata: SSE message 1\n\ndata: SSE message 2\n\ndata: SSE message 3\n\ndata: SSE message 4\n\n",
+	}
+
+	output := ""
+	go func() {
+		scanner := bufio.NewScanner(body)
 		for scanner.Scan() {
 			line := scanner.Text()
-
-			duration := time.Since(start)
-			assert.Less(t, duration, SSE_TIMEOUT_DURATION)
-			assert.True(t, strings.Contains(line, "data: SSE message") || line == "", "unexpected line: %s", line)
-
-			start = time.Now()
+			output += line + "\n"
 		}
-		assert.NoError(t, scanner.Err())
+	}()
+
+	time.Sleep(test_utils.SSE_DURATION / 2)
+	for i := 0; i < 5; i++ {
+		require.Equal(t, expectedOutput[i], output)
+		time.Sleep(test_utils.SSE_DURATION)
 	}
 }

--- a/integration_test/sse_test/sse_test.yaml
+++ b/integration_test/sse_test/sse_test.yaml
@@ -2,3 +2,11 @@ routes:
   - url: "http://sample-sse.test/sse"
     response:
       rewrite: "http://localhost:8092/sse"
+
+  - url: "http://sample-sse.test/sse-with-transform"
+    response:
+      rewrite: "http://localhost:8092/sse"
+      transform: "sed -u -e 's/data/DATA/'"
+      headers:
+        Content-Type: text/event-stream
+      

--- a/integration_test/sse_test/sse_test.yaml
+++ b/integration_test/sse_test/sse_test.yaml
@@ -1,6 +1,4 @@
 routes:
   - url: "http://sample-sse.test/sse"
     response:
-      rewrite:
-        proxy: "http://localhost:8092/sse"
-
+      rewrite: "http://localhost:8092/sse"

--- a/integration_test/utils.go
+++ b/integration_test/utils.go
@@ -1,17 +1,21 @@
 package test_utils
 
 import (
+	"bufio"
 	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
+	"testing"
 	"time"
 
 	"github.com/kajikentaro/flexy-proxy/loggers"
 	"github.com/kajikentaro/flexy-proxy/proxy"
 	"github.com/kajikentaro/flexy-proxy/utils"
+	"github.com/stretchr/testify/require"
 )
 
 var SSE_DURATION = 1 * time.Second
@@ -122,4 +126,39 @@ func Request(proxyUrl *url.URL, targetUrl string) (*http.Response, error) {
 		},
 	}
 	return client.Get(targetUrl)
+}
+
+func TestSSEStreams(t *testing.T, actual io.ReadCloser, isCapital bool) {
+	var isCapitalToExpected = map[bool][]string{
+		false: {
+			"data: SSE message 0\n\n",
+			"data: SSE message 0\n\ndata: SSE message 1\n\n",
+			"data: SSE message 0\n\ndata: SSE message 1\n\ndata: SSE message 2\n\n",
+			"data: SSE message 0\n\ndata: SSE message 1\n\ndata: SSE message 2\n\ndata: SSE message 3\n\n",
+			"data: SSE message 0\n\ndata: SSE message 1\n\ndata: SSE message 2\n\ndata: SSE message 3\n\ndata: SSE message 4\n\n",
+		},
+		true: {
+			"DATA: SSE message 0\n\n",
+			"DATA: SSE message 0\n\nDATA: SSE message 1\n\n",
+			"DATA: SSE message 0\n\nDATA: SSE message 1\n\nDATA: SSE message 2\n\n",
+			"DATA: SSE message 0\n\nDATA: SSE message 1\n\nDATA: SSE message 2\n\nDATA: SSE message 3\n\n",
+			"DATA: SSE message 0\n\nDATA: SSE message 1\n\nDATA: SSE message 2\n\nDATA: SSE message 3\n\nDATA: SSE message 4\n\n",
+		},
+	}
+	expected := isCapitalToExpected[isCapital]
+
+	output := ""
+	go func() {
+		scanner := bufio.NewScanner(actual)
+		for scanner.Scan() {
+			line := scanner.Text()
+			output += line + "\n"
+		}
+	}()
+
+	time.Sleep(SSE_DURATION / 2)
+	for i := 0; i < 5; i++ {
+		require.Equal(t, expected[i], output)
+		time.Sleep(SSE_DURATION)
+	}
 }

--- a/middlewares/transform.go
+++ b/middlewares/transform.go
@@ -2,7 +2,6 @@ package middlewares
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -59,15 +58,16 @@ func (t *Transform) Middleware(next http.RoundTripper) http.RoundTripper {
 		cmd.Env = append(os.Environ(), "REQ_BODY="+string(reqBody))
 		cmd.Stdin = res.Body
 
-		var stdout bytes.Buffer
-		cmd.Stdout = &stdout
-		var stderr bytes.Buffer
-		cmd.Stderr = &stderr
-		if err := cmd.Run(); err != nil {
-			return nil, fmt.Errorf("failed to execute command: '%s'\nError Log: \n%s", strings.Join((*t.command), " "), stderr.String())
+		// cmd.Stderr = os.Stdout
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			return nil, err
 		}
+		res.Body = stdout
 
-		res.Body = io.NopCloser(&stdout)
+		if err := cmd.Start(); err != nil {
+			return nil, err
+		}
 		return res, nil
 	})
 }

--- a/middlewares/transform.go
+++ b/middlewares/transform.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -19,6 +20,17 @@ type Transform struct {
 	command *[]string
 }
 
+func isProbablyText(contentType string) bool {
+	if contentType == "" ||
+		strings.HasPrefix(contentType, "text/") ||
+		contentType == "application/json" ||
+		contentType == "application/xml" ||
+		contentType == "application/x-www-form-urlencoded" {
+		return true
+	}
+	return false
+}
+
 func (t *Transform) Middleware(next http.RoundTripper) http.RoundTripper {
 	return roundTripperFunc(func(r *http.Request) (*http.Response, error) {
 		// NOTE: if the response body is compressed, we can't use string replacement commands like 'sed'.
@@ -29,7 +41,22 @@ func (t *Transform) Middleware(next http.RoundTripper) http.RoundTripper {
 			return nil, err
 		}
 
+		var reqBody []byte
+		if r.ContentLength > 1024*1024 {
+			reqBody = []byte("BODY env variable is only available for requests with Content-Length less than 1MB")
+		} else if !isProbablyText(r.Header.Get("Content-Type")) {
+			reqBody = []byte("BODY env variable is only available for text content types")
+		} else {
+			var err error
+			reqBody, err = io.ReadAll(r.Body)
+			if err != nil {
+				return nil, err
+			}
+			r.Body = io.NopCloser(bytes.NewReader(reqBody))
+		}
+
 		cmd := exec.Command((*t.command)[0], (*t.command)[1:]...)
+		cmd.Env = append(os.Environ(), "REQ_BODY="+string(reqBody))
 		cmd.Stdin = res.Body
 
 		var stdout bytes.Buffer

--- a/middlewares/transform.go
+++ b/middlewares/transform.go
@@ -57,17 +57,20 @@ func (t *Transform) Middleware(next http.RoundTripper) http.RoundTripper {
 		cmd := exec.Command((*t.command)[0], (*t.command)[1:]...)
 		cmd.Env = append(os.Environ(), "REQ_BODY="+string(reqBody))
 		cmd.Stdin = res.Body
+		pr, pw := io.Pipe()
+		cmd.Stdout = pw
+		cmd.Stderr = pw
 
-		// cmd.Stderr = os.Stdout
-		stdout, err := cmd.StdoutPipe()
-		if err != nil {
-			return nil, err
-		}
-		res.Body = stdout
+		res.Body = pr
 
 		if err := cmd.Start(); err != nil {
 			return nil, err
 		}
+
+		go func() {
+			cmd.Wait()
+			pw.Close()
+		}()
 		return res, nil
 	})
 }

--- a/middlewares/transform_sse_test.go
+++ b/middlewares/transform_sse_test.go
@@ -59,3 +59,15 @@ func TestTransformStream(t *testing.T) {
 
 	test_utils.TestSSEStreams(t, res.Body, true)
 }
+
+func TestTransformStreamStdErr(t *testing.T) {
+	command := []string{"bash", "-c", "sed -u -e 's/data/DATA/g' >&2"}
+	transform := middlewares.NewTransform(&command)
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.test", nil)
+	res, err := transform.Middleware(dummyStream{}).RoundTrip(req)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	test_utils.TestSSEStreams(t, res.Body, true)
+}

--- a/middlewares/transform_sse_test.go
+++ b/middlewares/transform_sse_test.go
@@ -49,7 +49,7 @@ func TestDummyStreamItself(t *testing.T) {
 }
 
 func TestTransformStream(t *testing.T) {
-	command := []string{"sed", "-E", "s/data/DATA/g"}
+	command := []string{"sed", "-u", "-e", "s/data/DATA/g"}
 	transform := middlewares.NewTransform(&command)
 
 	req := httptest.NewRequest(http.MethodGet, "http://example.test", nil)

--- a/middlewares/transform_sse_test.go
+++ b/middlewares/transform_sse_test.go
@@ -1,0 +1,61 @@
+package middlewares_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	test_utils "github.com/kajikentaro/flexy-proxy/integration_test"
+	"github.com/kajikentaro/flexy-proxy/middlewares"
+	"github.com/stretchr/testify/require"
+)
+
+var SSE_DURATION = time.Second
+
+type dummyStream struct{}
+
+func (d dummyStream) RoundTrip(_ *http.Request) (*http.Response, error) {
+	pr, pw := io.Pipe()
+
+	go func() {
+		defer pw.Close()
+		for i := 0; i < 5; i++ {
+			fmt.Fprintf(pw, "data: SSE message %d\n\n", i)
+			time.Sleep(SSE_DURATION)
+		}
+	}()
+
+	res := &http.Response{
+		Body:       pr,
+		Header:     make(http.Header),
+		Request:    nil,
+		StatusCode: http.StatusOK,
+	}
+
+	res.Header.Set("Content-Type", "text/event-stream")
+	return res, nil
+}
+
+func TestDummyStreamItself(t *testing.T) {
+	roundTripper := dummyStream{}
+	res, err := roundTripper.RoundTrip(nil)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	test_utils.TestSSEStreams(t, res.Body, false)
+}
+
+func TestTransformStream(t *testing.T) {
+	command := []string{"sed", "-E", "s/data/DATA/g"}
+	transform := middlewares.NewTransform(&command)
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.test", nil)
+	res, err := transform.Middleware(dummyStream{}).RoundTrip(req)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	test_utils.TestSSEStreams(t, res.Body, true)
+}

--- a/middlewares/transform_test.go
+++ b/middlewares/transform_test.go
@@ -41,6 +41,14 @@ func TestTransformMiddleware(t *testing.T) {
 			command:        []string{"sed", "-E", "s/foo/bar/g"},
 			expectedOutput: "bar",
 		},
+		{
+			name:           "Log request body",
+			requestBody:    "test request body",
+			responseBody:   "foo",
+			contentType:    "text/plain",
+			command:        []string{"bash", "-c", "echo $REQ_BODY"},
+			expectedOutput: "test request body\n",
+		},
 	}
 
 	for _, tt := range tests {
@@ -72,4 +80,40 @@ func TestTransformMiddlewareErrorCase(t *testing.T) {
 	res, err := transform.Middleware(dummyRoundTripper{resBody: "foo"}).RoundTrip(req)
 	assert.Error(t, err)
 	assert.Nil(t, res)
+}
+
+func TestTransformMiddlewareLargeBody(t *testing.T) {
+	command := []string{"bash", "-c", "echo $REQ_BODY"}
+	transform := NewTransform(&command)
+
+	largeBody := bytes.Repeat([]byte("a"), 1024*1024+1)
+
+	// Test for large body handling
+	req := httptest.NewRequest(http.MethodPost, "http://example.com", bytes.NewReader(largeBody))
+	req.Header.Set("Content-Type", "text/plain")
+
+	res, err := transform.Middleware(dummyRoundTripper{resBody: "foo"}).RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+	resBody, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	errorMessage := "BODY env variable is only available for requests with Content-Length less than 1MB\n"
+	assert.Equal(t, errorMessage, string(resBody))
+}
+
+func TestTransformMiddlewareNonTextContent(t *testing.T) {
+	command := []string{"bash", "-c", "echo $REQ_BODY"}
+	transform := NewTransform(&command)
+
+	// Test for non-text content handling
+	req := httptest.NewRequest(http.MethodPost, "http://example.com", bytes.NewReader([]byte("binary data")))
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	res, err := transform.Middleware(dummyRoundTripper{resBody: "foo"}).RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+	resBody, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	errorMessage := "BODY env variable is only available for text content types\n"
+	assert.Equal(t, errorMessage, string(resBody))
 }

--- a/middlewares/transform_test.go
+++ b/middlewares/transform_test.go
@@ -1,0 +1,75 @@
+package middlewares
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type dummyRoundTripper struct {
+	resBody string
+}
+
+func (d dummyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	res := httptest.NewRecorder()
+	res.Header().Set("Content-Type", "text/plain")
+	res.WriteHeader(http.StatusOK)
+	res.Body.Write([]byte(d.resBody))
+	return res.Result(), nil
+}
+
+func TestTransformMiddleware(t *testing.T) {
+
+	tests := []struct {
+		name           string
+		requestBody    string
+		responseBody   string
+		contentType    string
+		command        []string
+		expectedOutput string
+	}{
+		{
+			name:           "Transform response body",
+			requestBody:    "",
+			responseBody:   "foo",
+			contentType:    "text/plain",
+			command:        []string{"sed", "-E", "s/foo/bar/g"},
+			expectedOutput: "bar",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transform := NewTransform(&tt.command)
+
+			req := httptest.NewRequest(http.MethodPost, "http://example.com", bytes.NewReader([]byte(tt.requestBody)))
+			req.Header.Set("Content-Type", tt.contentType)
+
+			res, err := transform.Middleware(dummyRoundTripper{resBody: tt.responseBody}).RoundTrip(req)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusOK, res.StatusCode)
+			assert.Equal(t, "text/plain", res.Header.Get("Content-Type"))
+			resBody, err := io.ReadAll(res.Body)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedOutput, string(resBody))
+		})
+	}
+}
+
+func TestTransformMiddlewareErrorCase(t *testing.T) {
+	command := []string{"invalid_command"}
+	transform := NewTransform(&command)
+
+	// Test for error case when the command is invalid
+	req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
+	req.Header.Set("Content-Type", "text/plain")
+
+	res, err := transform.Middleware(dummyRoundTripper{resBody: "foo"}).RoundTrip(req)
+	assert.Error(t, err)
+	assert.Nil(t, res)
+}

--- a/middlewares/transform_test.go
+++ b/middlewares/transform_test.go
@@ -1,4 +1,4 @@
-package middlewares
+package middlewares_test
 
 import (
 	"bytes"
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/kajikentaro/flexy-proxy/middlewares"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -53,7 +54,7 @@ func TestTransformMiddleware(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			transform := NewTransform(&tt.command)
+			transform := middlewares.NewTransform(&tt.command)
 
 			req := httptest.NewRequest(http.MethodPost, "http://example.com", bytes.NewReader([]byte(tt.requestBody)))
 			req.Header.Set("Content-Type", tt.contentType)
@@ -71,7 +72,7 @@ func TestTransformMiddleware(t *testing.T) {
 
 func TestTransformMiddlewareErrorCase(t *testing.T) {
 	command := []string{"invalid_command"}
-	transform := NewTransform(&command)
+	transform := middlewares.NewTransform(&command)
 
 	// Test for error case when the command is invalid
 	req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
@@ -84,7 +85,7 @@ func TestTransformMiddlewareErrorCase(t *testing.T) {
 
 func TestTransformMiddlewareLargeBody(t *testing.T) {
 	command := []string{"bash", "-c", "echo $REQ_BODY"}
-	transform := NewTransform(&command)
+	transform := middlewares.NewTransform(&command)
 
 	largeBody := bytes.Repeat([]byte("a"), 1024*1024+1)
 
@@ -103,7 +104,7 @@ func TestTransformMiddlewareLargeBody(t *testing.T) {
 
 func TestTransformMiddlewareNonTextContent(t *testing.T) {
 	command := []string{"bash", "-c", "echo $REQ_BODY"}
-	transform := NewTransform(&command)
+	transform := middlewares.NewTransform(&command)
 
 	// Test for non-text content handling
 	req := httptest.NewRequest(http.MethodPost, "http://example.com", bytes.NewReader([]byte("binary data")))

--- a/routers/routers.go
+++ b/routers/routers.go
@@ -174,7 +174,7 @@ func (r *router) TryRoundTrip(req *http.Request) (map[string]string, *http.Respo
 		return nil, nil, err
 	}
 
-	middleware := middlewares.NewCommonMiddleware(
+	common := middlewares.NewCommonMiddleware(
 		route.Response.ContentType,
 		route.Response.Status,
 		route.Response.Headers,
@@ -186,7 +186,7 @@ func (r *router) TryRoundTrip(req *http.Request) (map[string]string, *http.Respo
 		return nil, nil, err
 	}
 
-	res, err := middleware.Middleware(main).RoundTrip(req)
+	res, err := common.Middleware(main).RoundTrip(req)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
* on transform commands, `$REQ_BODY` contains request body
* support SSE communication even if transform commands are used