### PR TITLE
Feat: Reuse transport for upstream HTTP connections

### DIFF
--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -1,0 +1,35 @@
+## Package Architecture
+
+The main request path runs from the proxy through route matching and middleware to one of the response handlers.
+
+```mermaid
+flowchart LR
+    Main["main<br/>CLI and HTTP server"]
+    Proxy["proxy<br/>HTTP(S), MITM, request lifecycle"]
+    Routers["routers<br/>Route matching"]
+    Middlewares["middlewares<br/>Transform, headers, status"]
+
+    subgraph Responders["Response handlers (routers)"]
+        Content["ContentResponder"]
+        File["FileResponder"]
+        ReverseProxy["ReverseProxyTransport"]
+    end
+
+    Main --> Proxy
+    Proxy --> Routers
+    Routers --> Middlewares
+    Middlewares --> Content
+    Middlewares --> File
+    Middlewares --> ReverseProxy
+
+    Cache["utils/cache<br/>TLS certificate cache"]
+    Proxy -.-> Cache
+```
+
+When making changes:
+
+- Update `models` and `models/config-spec.json` for configuration schema changes.
+- Update `routers` for route matching or Content, File, and Rewrite behavior.
+- Update `middlewares` for response transformations and common response overrides.
+- Update `proxy` for HTTP proxying, HTTPS interception, certificates, and request lifecycle behavior.
+- Add end-to-end coverage under `integration_test`.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,39 @@ An easy-to-start, YAML-based flexible proxy server for software development. Ret
   - Connect to another proxy.
   - Deny access.
 
+**Request Flow**
+
+```mermaid
+flowchart LR
+    Client["Client"] -->|"HTTP / HTTPS request"| Proxy["Flexy Proxy"]
+    Config["YAML configuration"] -->|"routes, certificates,<br/>default route"| Proxy
+
+    Proxy --> Router{"Route matched?"}
+
+    Router -->|"Yes"| Handler{"Response handler"}
+    Handler --> Content["Content"]
+    Handler --> File["File"]
+    Handler --> Rewrite["Rewrite"]
+    Rewrite <-->|"HTTP / HTTPS"| Upstream["Upstream server"]
+
+    Content --> Transform{"Transform configured?"}
+    File --> Transform
+    Rewrite --> Transform
+    Transform -->|"Yes"| Command["External command"]
+    Transform -->|"No"| Response["Response"]
+    Command --> Response
+
+    Router -->|"No"| Default{"Default route"}
+    Default --> Internet["Connect to internet"]
+    Default --> ParentProxy["Connect through<br/>another proxy"]
+    Default --> Deny["Deny access"]
+
+    Internet --> Response
+    ParentProxy --> Response
+    Deny --> Response
+    Response --> Client
+```
+
 ## Installation
 
 ### Binary Download
@@ -111,7 +144,6 @@ routes:
       rewrite:
         to: "https://example.com"
 ```
-
 
 ## Certificates
 

--- a/integration_test/always_mitm_test/always_mitm_test.go
+++ b/integration_test/always_mitm_test/always_mitm_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var PROXY_PORT_NUMBER = 8093
+var PROXY_PORT_NUMBER = test_utils.PORT_NUM_ALWAYS_MITM
 var PROXY_HTTP_ADDRESS = fmt.Sprintf(":%d", PROXY_PORT_NUMBER)
 var PROXY_URL, _ = url.Parse(
 	fmt.Sprintf("http://localhost:%d", PROXY_PORT_NUMBER),

--- a/integration_test/benchmark_test/benchmark.yaml
+++ b/integration_test/benchmark_test/benchmark.yaml
@@ -1,0 +1,19 @@
+log_level: "ERROR"
+
+routes:
+  - url: "http://example.com/contents"
+    response:
+      content: "benchmark content response"
+
+  - url: "http://example.com/rewrite"
+    response:
+      rewrite: "http://localhost:8095/"
+
+  - url: "http://example.com/file"
+    response:
+      file: "file.txt"
+
+  - url: "http://example.com/rewrite-transform"
+    response:
+      rewrite: "http://localhost:8095/"
+      transform: "bash ./wc.sh"

--- a/integration_test/benchmark_test/benchmark_test.go
+++ b/integration_test/benchmark_test/benchmark_test.go
@@ -1,0 +1,150 @@
+package test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"testing"
+
+	test_utils "github.com/kajikentaro/flexy-proxy/integration_test"
+	"github.com/kajikentaro/flexy-proxy/loggers"
+)
+
+const (
+	proxyHTTPAddress      = ":%d"
+	proxyURLFormat        = "http://localhost:%d"
+	sampleServerURLFormat = "http://localhost:%d"
+)
+
+var (
+	proxyAddress        = fmt.Sprintf(proxyHTTPAddress, test_utils.PORT_NUM_BENCHMARK)
+	proxyURL            = fmt.Sprintf(proxyURLFormat, test_utils.PORT_NUM_BENCHMARK)
+	sampleServerAddress = fmt.Sprintf(proxyHTTPAddress, test_utils.PORT_NUM_BENCHMARK_SERVER)
+	sampleServerURL     = fmt.Sprintf(sampleServerURLFormat, test_utils.PORT_NUM_BENCHMARK_SERVER)
+)
+
+func TestMain(m *testing.M) {
+	{
+		// setup proxy server
+		ctx, cancel := context.WithCancel(context.Background())
+		err := test_utils.StartProxyServer(ctx, proxyAddress, "benchmark.yaml")
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "failed to start proxy server:", err)
+			os.Exit(1)
+		}
+		defer cancel()
+	}
+
+	{
+		// setup sample HTTP server
+		ctx, cancel := context.WithCancel(context.Background())
+		err := test_utils.StartSampleHttpServer(
+			ctx,
+			sampleServerAddress,
+			loggers.GenLogger(nil),
+		)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "failed to start sample HTTP server:", err)
+			os.Exit(1)
+		}
+		defer cancel()
+	}
+
+	m.Run()
+}
+
+func newHTTPClient(b *testing.B, proxyAddress string) *http.Client {
+	b.Helper()
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	if proxyAddress != "" {
+		parsedProxyURL, err := url.Parse(proxyAddress)
+		if err != nil {
+			b.Fatalf("parse proxy URL: %v", err)
+		}
+		transport.Proxy = http.ProxyURL(parsedProxyURL)
+	} else {
+		transport.Proxy = nil
+	}
+
+	b.Cleanup(transport.CloseIdleConnections)
+	return &http.Client{Transport: transport}
+}
+
+func benchmarkGET(b *testing.B, client *http.Client, targetURL, expectedBody string) {
+	b.Helper()
+	expected := []byte(expectedBody)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		res, err := client.Get(targetURL)
+		if err != nil {
+			b.Fatalf("GET %s: %v", targetURL, err)
+		}
+
+		body, readErr := io.ReadAll(res.Body)
+		closeErr := res.Body.Close()
+		if readErr != nil {
+			b.Fatalf("read response from %s: %v", targetURL, readErr)
+		}
+		if closeErr != nil {
+			b.Fatalf("close response from %s: %v", targetURL, closeErr)
+		}
+		if res.StatusCode != http.StatusOK {
+			b.Fatalf("GET %s returned status %s", targetURL, res.Status)
+		}
+		if !bytes.Equal(body, expected) {
+			b.Fatalf("GET %s returned %q, want %q", targetURL, body, expected)
+		}
+	}
+}
+
+// BenchmarkHTTPGet measures direct HTTP access as the baseline.
+func BenchmarkHTTPGet(b *testing.B) {
+	benchmarkGET(b, newHTTPClient(b, ""), sampleServerURL, "hello,world")
+}
+
+func BenchmarkProxyHTTPGet(b *testing.B) {
+	benchmarkGET(b, newHTTPClient(b, proxyURL), sampleServerURL, "hello,world")
+}
+
+func BenchmarkProxyContent(b *testing.B) {
+	benchmarkGET(
+		b,
+		newHTTPClient(b, proxyURL),
+		"http://example.com/contents",
+		"benchmark content response",
+	)
+}
+
+func BenchmarkProxyRewrite(b *testing.B) {
+	benchmarkGET(
+		b,
+		newHTTPClient(b, proxyURL),
+		"http://example.com/rewrite",
+		"hello,world",
+	)
+}
+
+func BenchmarkProxyFile(b *testing.B) {
+	benchmarkGET(
+		b,
+		newHTTPClient(b, proxyURL),
+		"http://example.com/file",
+		"hello file",
+	)
+}
+
+func BenchmarkProxyRewriteTransform(b *testing.B) {
+	benchmarkGET(
+		b,
+		newHTTPClient(b, proxyURL),
+		"http://example.com/rewrite-transform",
+		"11\n",
+	)
+}

--- a/integration_test/benchmark_test/file.txt
+++ b/integration_test/benchmark_test/file.txt
@@ -1,0 +1,1 @@
+hello file

--- a/integration_test/benchmark_test/wc.sh
+++ b/integration_test/benchmark_test/wc.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+wc -c

--- a/integration_test/certificate_test/certificate_test.go
+++ b/integration_test/certificate_test/certificate_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var PROXY_PORT_NUMBER = 8090
+var PROXY_PORT_NUMBER = test_utils.PORT_NUM_CERTIFICATE
 var PROXY_HTTP_ADDRESS = fmt.Sprintf(":%d", PROXY_PORT_NUMBER)
 var PROXY_URL, _ = url.Parse(fmt.Sprintf("http://localhost:%d", PROXY_PORT_NUMBER))
 

--- a/integration_test/proxy_test/1st_proxy_overwrite_default.yaml
+++ b/integration_test/proxy_test/1st_proxy_overwrite_default.yaml
@@ -11,7 +11,7 @@ routes:
     response:
       rewrite:
         from: ".*"
-        to: "http://localhost:8089"
+        to: "http://localhost:8087"
         regex: true
         proxy: "" # remove the default proxy
 

--- a/integration_test/proxy_test/proxy_test.go
+++ b/integration_test/proxy_test/proxy_test.go
@@ -14,14 +14,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var PROXY_PORT_NUMBER_1 = 8083
+var PROXY_PORT_NUMBER_1 = test_utils.PORT_NUM_PROXY_1
 var PROXY_HTTP_ADDRESS_1 = fmt.Sprintf(":%d", PROXY_PORT_NUMBER_1)
 var PROXY_URL_1 = fmt.Sprintf("http://localhost:%d", PROXY_PORT_NUMBER_1)
 
-var PROXY_PORT_NUMBER_2 = 8084
+var PROXY_PORT_NUMBER_2 = test_utils.PORT_NUM_PROXY_2
 var PROXY_HTTP_ADDRESS_2 = fmt.Sprintf(":%d", PROXY_PORT_NUMBER_2)
 
-var SAMPLE_SERVER_PORT_NUMBER = 8089
+var SAMPLE_SERVER_PORT_NUMBER = test_utils.PORT_NUM_PROXY_3
 var SAMPLE_SERVER_HTTP_ADDRESS = fmt.Sprintf(":%d", SAMPLE_SERVER_PORT_NUMBER)
 
 func TestDefaultRoute(t *testing.T) {

--- a/integration_test/regex_route_test/regex_route_test.go
+++ b/integration_test/regex_route_test/regex_route_test.go
@@ -14,11 +14,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var PROXY_PORT_NUMBER = 8085
+var PROXY_PORT_NUMBER = test_utils.PORT_NUM_REGEX_ROUTE_1
 var PROXY_HTTP_ADDRESS = fmt.Sprintf(":%d", PROXY_PORT_NUMBER)
 var PROXY_URL = fmt.Sprintf("http://localhost:%d", PROXY_PORT_NUMBER)
 
-var SAMPLE_SERVER_PORT_NUMBER = 8086
+var SAMPLE_SERVER_PORT_NUMBER = test_utils.PORT_NUM_REGEX_ROUTE_2
 var SAMPLE_SERVER_HTTP_ADDRESS = fmt.Sprintf(":%d", SAMPLE_SERVER_PORT_NUMBER)
 
 func fatalln(a ...any) {
@@ -113,7 +113,7 @@ func TestReverseProxy(t *testing.T) {
 	proxyUrl, err := url.Parse(PROXY_URL)
 	assert.NoError(t, err)
 
-	res, err := test_utils.Request(proxyUrl, "http://localhost:8086/path/v1.2-win64.zip")
+	res, err := test_utils.Request(proxyUrl, fmt.Sprintf("http://localhost:%d/path/v1.2-win64.zip", test_utils.PORT_NUM_REGEX_ROUTE_2))
 	assert.NoError(t, err)
 	defer res.Body.Close()
 

--- a/integration_test/reserved_ports.go
+++ b/integration_test/reserved_ports.go
@@ -1,0 +1,21 @@
+package test_utils
+
+// In order to avoid port conflicts during parallel test executions,
+// we define reserved port numbers here.
+const (
+	PORT_NUM_ROUTE = iota + 8081
+	PORT_NUM_ROUTE_SERVER
+	PORT_NUM_PROXY_1
+	PORT_NUM_PROXY_2
+	PORT_NUM_REGEX_ROUTE_1
+	PORT_NUM_REGEX_ROUTE_2
+	PORT_NUM_PROXY_3
+	PORT_NUM_TRANSFORM
+	PORT_NUM_TRANSFORM_SERVER
+	PORT_NUM_CERTIFICATE
+	PORT_NUM_SSE
+	PORT_NUM_SSE_SERVER
+	PORT_NUM_ALWAYS_MITM
+	PORT_NUM_BENCHMARK
+	PORT_NUM_BENCHMARK_SERVER
+)

--- a/integration_test/route_test/route_test.go
+++ b/integration_test/route_test/route_test.go
@@ -19,13 +19,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var PROXY_PORT_NUMBER = 8081
+var PROXY_PORT_NUMBER = test_utils.PORT_NUM_ROUTE
 var PROXY_HTTP_ADDRESS = fmt.Sprintf(":%d", PROXY_PORT_NUMBER)
 var PROXY_URL, _ = url.Parse(
 	fmt.Sprintf("http://localhost:%d", PROXY_PORT_NUMBER),
 )
 
-var SAMPLE_SERVER_PORT_NUMBER = 8082
+var SAMPLE_SERVER_PORT_NUMBER = test_utils.PORT_NUM_ROUTE_SERVER
 var SAMPLE_SERVER_HTTP_ADDRESS = fmt.Sprintf(":%d", SAMPLE_SERVER_PORT_NUMBER)
 
 func TestRequestOnConfigUrl(t *testing.T) {

--- a/integration_test/sse_test/sse_test.go
+++ b/integration_test/sse_test/sse_test.go
@@ -16,11 +16,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var PROXY_PORT_NUMBER = 8091
+var PROXY_PORT_NUMBER = test_utils.PORT_NUM_SSE
 var PROXY_HTTP_ADDRESS = fmt.Sprintf(":%d", PROXY_PORT_NUMBER)
 var PROXY_URL, _ = url.Parse(fmt.Sprintf("http://localhost:%d", PROXY_PORT_NUMBER))
 
-var SAMPLE_SERVER_PORT_NUMBER = 8092
+var SAMPLE_SERVER_PORT_NUMBER = test_utils.PORT_NUM_SSE_SERVER
 var SAMPLE_SERVER_HTTP_ADDRESS = fmt.Sprintf(":%d", SAMPLE_SERVER_PORT_NUMBER)
 var SAMPLE_SERVER_URL = fmt.Sprintf("http://localhost:%d", SAMPLE_SERVER_PORT_NUMBER)
 
@@ -61,7 +61,7 @@ func TestSSEWithoutProxy(t *testing.T) {
 
 // test SSE communication with proxy but without rewrite
 func TestSSEWithProxyWithoutRewrite(t *testing.T) {
-	res, err := test_utils.Request(PROXY_URL, "http://localhost:8092/sse")
+	res, err := test_utils.Request(PROXY_URL, fmt.Sprintf("http://localhost:%d/sse", test_utils.PORT_NUM_SSE_SERVER))
 	assert.NoError(t, err)
 	defer res.Body.Close()
 

--- a/integration_test/transform_test/transform_test.go
+++ b/integration_test/transform_test/transform_test.go
@@ -15,11 +15,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var PROXY_PORT_NUMBER = 8087
+var PROXY_PORT_NUMBER = test_utils.PORT_NUM_TRANSFORM
 var PROXY_HTTP_ADDRESS = fmt.Sprintf(":%d", PROXY_PORT_NUMBER)
 var PROXY_URL = fmt.Sprintf("http://localhost:%d", PROXY_PORT_NUMBER)
 
-var SAMPLE_SERVER_PORT_NUMBER = 8088
+var SAMPLE_SERVER_PORT_NUMBER = test_utils.PORT_NUM_TRANSFORM_SERVER
 var SAMPLE_SERVER_HTTP_ADDRESS = fmt.Sprintf(":%d", SAMPLE_SERVER_PORT_NUMBER)
 
 func fatalln(a ...any) {

--- a/integration_test/transform_test/transform_test.yaml
+++ b/integration_test/transform_test/transform_test.yaml
@@ -19,7 +19,7 @@ routes:
 
   - url: "https://reverse-proxy.test/"
     response:
-      rewrite: "http://localhost:8088/"
+      rewrite: "http://localhost:8089/"
       transform: "bash ./wc.sh"
 
   ##########
@@ -40,7 +40,7 @@ routes:
 
   - url: "http://reverse-proxy.test/"
     response:
-      rewrite: "http://localhost:8088/"
+      rewrite: "http://localhost:8089/"
       transform: "bash ./wc.sh"
 
 default_route:

--- a/routers/handle_reverse_proxy.go
+++ b/routers/handle_reverse_proxy.go
@@ -10,10 +10,9 @@ import (
 
 func NewReverseProxyTransport(proxyUrl *url.URL, urlReplacer UrlReplacer, insecureCipherSuites bool, reqHeaders map[string]string) http.RoundTripper {
 	return &ReverseProxyTransport{
-		proxyUrl:             proxyUrl,
-		urlReplacer:          urlReplacer,
-		insecureCipherSuites: insecureCipherSuites,
-		reqHeaders:           reqHeaders,
+		transport:   utils.GetTransport(insecureCipherSuites, proxyUrl),
+		urlReplacer: urlReplacer,
+		reqHeaders:  reqHeaders,
 	}
 }
 
@@ -22,10 +21,9 @@ type UrlReplacer interface {
 }
 
 type ReverseProxyTransport struct {
-	proxyUrl             *url.URL
-	urlReplacer          UrlReplacer
-	insecureCipherSuites bool
-	reqHeaders           map[string]string
+	transport   *http.Transport
+	urlReplacer UrlReplacer
+	reqHeaders  map[string]string
 }
 
 func (c *ReverseProxyTransport) RoundTrip(r *http.Request) (*http.Response, error) {
@@ -60,8 +58,7 @@ func (c *ReverseProxyTransport) RoundTrip(r *http.Request) (*http.Response, erro
 	})
 	rr.Host = getReplacedHost()
 
-	t := utils.GetTransport(c.insecureCipherSuites, c.proxyUrl)
-	res, err := t.RoundTrip(rr)
+	res, err := c.transport.RoundTrip(rr)
 	if err != nil {
 		return nil, err
 	}

--- a/routers/handle_reverse_proxy_test.go
+++ b/routers/handle_reverse_proxy_test.go
@@ -2,9 +2,11 @@ package routers
 
 import (
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -73,4 +75,28 @@ func TestReverseProxyTransportHostPriority(t *testing.T) {
 		assert.Equal(t, mustParseURL(t, url).Host, gotHost)
 		assert.Equal(t, url, resp.Header.Get(HEADER_REWRITE_TO))
 	})
+}
+
+func TestReverseProxyTransportReusesConnections(t *testing.T) {
+	var connections atomic.Int32
+	target := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	}))
+	target.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			connections.Add(1)
+		}
+	}
+	target.Start()
+	defer target.Close()
+
+	roundTripper := NewReverseProxyTransport(nil, nil, false, nil)
+	for range 2 {
+		resp := sendRequest(t, roundTripper, target.URL)
+		_, err := io.Copy(io.Discard, resp.Body)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+	}
+
+	assert.Equal(t, int32(1), connections.Load())
 }

--- a/utils/cache/lru_benchmark_test.go
+++ b/utils/cache/lru_benchmark_test.go
@@ -1,0 +1,58 @@
+package cache
+
+import (
+	"sync"
+	"testing"
+)
+
+var MAX_SIZE = 1000
+
+func BenchmarkLRUCacheStore(b *testing.B) {
+	cache := NewLRUCache[string, string](MAX_SIZE)
+	for i := 0; i < b.N; i++ {
+		key := string(rune(i))
+		cache.Store(key, "test value")
+	}
+}
+
+func BenchmarkLRUCacheLoad(b *testing.B) {
+	cache := NewLRUCache[string, string](MAX_SIZE)
+	for i := 0; i < b.N; i++ {
+		key := string(rune(i))
+		cache.Store(key, "test value")
+	}
+
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		key := string(rune(i))
+		cache.Load(key)
+	}
+	b.StopTimer()
+}
+
+/**
+ * Benchmark for normal map for comparison
+ */
+
+func BenchmarkNormalMapStore(b *testing.B) {
+	m := sync.Map{}
+	for i := 0; i < b.N; i++ {
+		key := string(rune(i))
+		m.Store(key, "test value")
+	}
+}
+
+func BenchmarkNormalMapLoad(b *testing.B) {
+	m := sync.Map{}
+	for i := 0; i < b.N; i++ {
+		key := string(rune(i))
+		m.Store(key, "test value")
+	}
+
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		key := string(rune(i))
+		m.Load(key)
+	}
+	b.StopTimer()
+}


### PR DESCRIPTION
**AS_IS**
```
go test ./integration_test/benchmark_test -bench=. -benchtime=1s 
goos: linux
goarch: amd64
pkg: github.com/kajikentaro/flexy-proxy/integration_test/benchmark_test
cpu: AMD Ryzen 7 7700 8-Core Processor              
BenchmarkHTTPGet-16                        38799             30057 ns/op            6305 B/op         69 allocs/op
BenchmarkProxyHTTPGet-16                   19086             62911 ns/op           14658 B/op        181 allocs/op
BenchmarkProxyContent-16                   36552             32021 ns/op            9109 B/op        118 allocs/op
BenchmarkProxyRewrite-16                    6447            170866 ns/op           42610 B/op        305 allocs/op
BenchmarkProxyFile-16                      25657             46708 ns/op            9410 B/op        134 allocs/op
BenchmarkProxyRewriteTransform-16            381           3144779 ns/op          136104 B/op        495 allocs/op
PASS
ok      github.com/kajikentaro/flexy-proxy/integration_test/benchmark_test      10.753s
```


**TO_BE**
```
go test ./integration_test/benchmark_test -bench=. -benchtime=1s
goos: linux
goarch: amd64
pkg: github.com/kajikentaro/flexy-proxy/integration_test/benchmark_test
cpu: AMD Ryzen 7 7700 8-Core Processor              
BenchmarkHTTPGet-16                        37690             29681 ns/op            6305 B/op        69 allocs/op
BenchmarkProxyHTTPGet-16                   18592             66392 ns/op           14438 B/op        181 allocs/op
BenchmarkProxyContent-16                   36042             33073 ns/op            9113 B/op        118 allocs/op
BenchmarkProxyRewrite-16                   17672             69020 ns/op           15825 B/op        194 allocs/op
BenchmarkProxyFile-16                      24235             48891 ns/op           11143 B/op        134 allocs/op
BenchmarkProxyRewriteTransform-16            772           1508917 ns/op          124100 B/op        391 allocs/op
PASS
ok      github.com/kajikentaro/flexy-proxy/integration_test/benchmark_test      10.189s
```