### PR TITLE
Use a relative path from config.yaml as a working directory

### DIFF
--- a/middlewares/common.go
+++ b/middlewares/common.go
@@ -4,12 +4,13 @@ import (
 	"net/http"
 )
 
-func NewCommonMiddleware(contentType string, statusCode int, headers map[string]string, parsedTransformCommand *[]string) *CommonMiddleware {
+func NewCommonMiddleware(contentType string, statusCode int, headers map[string]string, parsedTransformCommand *[]string, workDir string) *CommonMiddleware {
 	return &CommonMiddleware{
 		contentType:            contentType,
 		statusCode:             statusCode,
 		headers:                headers,
 		parsedTransformCommand: parsedTransformCommand,
+		workDir:                workDir,
 	}
 }
 
@@ -18,6 +19,7 @@ type CommonMiddleware struct {
 	contentType            string
 	headers                map[string]string
 	parsedTransformCommand *[]string
+	workDir                string
 }
 
 func (h *CommonMiddleware) Middleware(next http.RoundTripper) http.RoundTripper {
@@ -28,7 +30,7 @@ func (h *CommonMiddleware) Middleware(next http.RoundTripper) http.RoundTripper 
 		if h.parsedTransformCommand == nil {
 			res, err = next.RoundTrip(r)
 		} else {
-			transform := NewTransform(h.parsedTransformCommand)
+			transform := NewTransform(h.parsedTransformCommand, h.workDir)
 			res, err = transform.Middleware(next).RoundTrip(r)
 		}
 

--- a/middlewares/transform.go
+++ b/middlewares/transform.go
@@ -10,14 +10,16 @@ import (
 	"strings"
 )
 
-func NewTransform(command *[]string) *Transform {
+func NewTransform(command *[]string, workDir string) *Transform {
 	return &Transform{
 		command: command,
+		workDir: workDir,
 	}
 }
 
 type Transform struct {
 	command *[]string
+	workDir string
 }
 
 func isProbablyText(contentType string) bool {
@@ -80,6 +82,7 @@ func (t *Transform) Middleware(next http.RoundTripper) http.RoundTripper {
 
 		res.Body = pr
 
+		cmd.Dir = t.workDir
 		if err := cmd.Start(); err != nil {
 			return nil, err
 		}

--- a/middlewares/transform_sse_test.go
+++ b/middlewares/transform_sse_test.go
@@ -50,7 +50,7 @@ func TestDummyStreamItself(t *testing.T) {
 
 func TestTransformStream(t *testing.T) {
 	command := []string{"sed", "-u", "-e", "s/data/DATA/g"}
-	transform := middlewares.NewTransform(&command)
+	transform := middlewares.NewTransform(&command, ".")
 
 	req := httptest.NewRequest(http.MethodGet, "http://example.test", nil)
 	res, err := transform.Middleware(dummyStream{}).RoundTrip(req)
@@ -62,7 +62,7 @@ func TestTransformStream(t *testing.T) {
 
 func TestTransformStreamStdErr(t *testing.T) {
 	command := []string{"bash", "-c", "sed -u -e 's/data/DATA/g' >&2"}
-	transform := middlewares.NewTransform(&command)
+	transform := middlewares.NewTransform(&command, ".")
 
 	req := httptest.NewRequest(http.MethodGet, "http://example.test", nil)
 	res, err := transform.Middleware(dummyStream{}).RoundTrip(req)

--- a/middlewares/transform_test.go
+++ b/middlewares/transform_test.go
@@ -62,7 +62,7 @@ func TestTransformMiddleware(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			transform := middlewares.NewTransform(&tt.command)
+			transform := middlewares.NewTransform(&tt.command, ".")
 
 			req := httptest.NewRequest(http.MethodPost, "http://example.com", bytes.NewReader([]byte(tt.requestBody)))
 			req.Header.Set("Content-Type", tt.contentType)
@@ -80,7 +80,7 @@ func TestTransformMiddleware(t *testing.T) {
 
 func TestTransformMiddlewareErrorCase(t *testing.T) {
 	command := []string{"invalid_command"}
-	transform := middlewares.NewTransform(&command)
+	transform := middlewares.NewTransform(&command, ".")
 
 	// Test for error case when the command is invalid
 	req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
@@ -93,7 +93,7 @@ func TestTransformMiddlewareErrorCase(t *testing.T) {
 
 func TestTransformMiddlewareLargeBody(t *testing.T) {
 	command := []string{"bash", "-c", "echo $REQ_BODY"}
-	transform := middlewares.NewTransform(&command)
+	transform := middlewares.NewTransform(&command, ".")
 
 	largeBody := bytes.Repeat([]byte("a"), 1024*1024+1)
 
@@ -112,7 +112,7 @@ func TestTransformMiddlewareLargeBody(t *testing.T) {
 
 func TestTransformMiddlewareNonTextContent(t *testing.T) {
 	command := []string{"bash", "-c", "echo $REQ_BODY"}
-	transform := middlewares.NewTransform(&command)
+	transform := middlewares.NewTransform(&command, ".")
 
 	// Test for non-text content handling
 	req := httptest.NewRequest(http.MethodPost, "http://example.com", bytes.NewReader([]byte("binary data")))
@@ -129,13 +129,28 @@ func TestTransformMiddlewareNonTextContent(t *testing.T) {
 
 func TestURLEnvironmentVariable(t *testing.T) {
 	command := []string{"bash", "-c", "echo $URL"}
-	transform := middlewares.NewTransform(&command)
+	transform := middlewares.NewTransform(&command, ".")
 
 	req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
-	res, err := transform.Middleware(dummyRoundTripper{resBody: "foo"}).RoundTrip(req)
+	res, err := transform.Middleware(dummyRoundTripper{}).RoundTrip(req)
 	require.NoError(t, err)
 
 	resBody, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 	assert.Equal(t, "http://example.com\n", string(resBody))
+}
+
+func TestWorkingDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	command := []string{"pwd"}
+	transform := middlewares.NewTransform(&command, tmpDir)
+
+	req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
+	res, err := transform.Middleware(dummyRoundTripper{}).RoundTrip(req)
+	require.NoError(t, err)
+
+	resBody, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	assert.Equal(t, tmpDir+"\n", string(resBody))
 }

--- a/routers/routers.go
+++ b/routers/routers.go
@@ -27,7 +27,7 @@ type ActiveRoute struct {
 
 var regHttpOrHttps = regexp.MustCompile(`^https?://`)
 
-func parse(config *models.RawConfig) ([]ActiveRoute, error) {
+func parse(config *models.RawConfig, workDir string) ([]ActiveRoute, error) {
 	var defaultProxy *url.URL
 	if config.DefaultRoute.Proxy != "" {
 		var err error
@@ -142,6 +142,7 @@ func parse(config *models.RawConfig) ([]ActiveRoute, error) {
 			r.Response.Status,
 			r.Response.Headers,
 			r.parsedTransformCommand,
+			workDir,
 		)
 
 		route := ActiveRoute{
@@ -157,8 +158,8 @@ func parse(config *models.RawConfig) ([]ActiveRoute, error) {
 	return roundTrippers, nil
 }
 
-func NewRouter(config *models.RawConfig) (models.Router, error) {
-	routes, err := parse(config)
+func NewRouter(config *models.RawConfig, workDir string) (models.Router, error) {
+	routes, err := parse(config, workDir)
 	if err != nil {
 		return nil, err
 	}

--- a/routers/routers_test.go
+++ b/routers/routers_test.go
@@ -16,7 +16,7 @@ func TestParse(t *testing.T) {
 				{Url: "http://example.com"},
 				{Url: "https://secure.com"},
 			}}
-		actual, err := parse(config)
+		actual, err := parse(config, ".")
 		require.NoError(t, err)
 
 		assert.Nil(t, actual[0].regexUrl)
@@ -34,7 +34,7 @@ func TestParse(t *testing.T) {
 				{Url: "example.com"},
 			},
 		}
-		actual, err := parse(config)
+		actual, err := parse(config, ".")
 		assert.ErrorContains(t, err, "URL must start with https:// or http://")
 		assert.Nil(t, actual)
 	})
@@ -45,7 +45,7 @@ func TestParse(t *testing.T) {
 				{Url: "http://"},
 				{Url: "https://"},
 			}}
-		actual, err := parse(config)
+		actual, err := parse(config, ".")
 		assert.ErrorContains(t, err, "URL must have a host")
 		assert.Nil(t, actual)
 	})
@@ -79,7 +79,7 @@ func TestGetMatchedRoute(t *testing.T) {
 			},
 		}}
 
-	router, err := NewRouter(config)
+	router, err := NewRouter(config, ".")
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -110,7 +110,7 @@ func TestRegexRouteDoesNotMatchQueryParam(t *testing.T) {
 				Regex: true,
 			},
 		}}
-	router, err := NewRouter(config)
+	router, err := NewRouter(config, ".")
 	require.NoError(t, err)
 
 	input := "https://example.com?callback=https://foo.dev"

--- a/utils/configs/utils.go
+++ b/utils/configs/utils.go
@@ -26,7 +26,8 @@ func ParseConfig(configPath string) (*proxy.Config, error) {
 		return nil, err
 	}
 
-	proxyConfig, err := parseRawConfig(rawConfig)
+	configFileDir := filepath.Dir(configPath)
+	proxyConfig, err := parseRawConfig(rawConfig, configFileDir)
 	if err != nil {
 		return nil, err
 	}
@@ -95,8 +96,38 @@ func convertToError(errs []gojsonschema.ResultError) error {
 	return errors.New(text)
 }
 
-func parseRawConfig(rawConfig *models.RawConfig) (*proxy.Config, error) {
-	router, err := routers.NewRouter(rawConfig)
+func loadCertificate(certPath string, certKeyPath string, baseDir string) (*tls.Certificate, error) {
+	if certPath == "" && certKeyPath == "" {
+		return nil, nil
+	}
+
+	if certPath == "" || certKeyPath == "" {
+		return nil, fmt.Errorf("both 'certificate' and 'certificate_key' should be specified in the config file")
+	}
+
+	if !filepath.IsAbs(certPath) {
+		certPath = filepath.Join(baseDir, certPath)
+	}
+	if !filepath.IsAbs(certKeyPath) {
+		certKeyPath = filepath.Join(baseDir, certKeyPath)
+	}
+
+	if _, err := os.Stat(certPath); errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("certificate, '%s', does not exist", certPath)
+	}
+	if _, err := os.Stat(certKeyPath); errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("certificate_key, '%s', does not exist", certKeyPath)
+	}
+	cert, err := tls.LoadX509KeyPair(certPath, certKeyPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load certificate: %w", err)
+	}
+
+	return &cert, nil
+}
+
+func parseRawConfig(rawConfig *models.RawConfig, configFileDir string) (*proxy.Config, error) {
+	router, err := routers.NewRouter(rawConfig, configFileDir)
 	if err != nil {
 		return nil, err
 	}
@@ -111,23 +142,9 @@ func parseRawConfig(rawConfig *models.RawConfig) (*proxy.Config, error) {
 		}
 	}
 
-	// load certificates
-	var cer *tls.Certificate
-	if rawConfig.Certificate != "" || rawConfig.CertificateKey != "" {
-		if rawConfig.Certificate == "" || rawConfig.CertificateKey == "" {
-			return nil, fmt.Errorf("both 'certificate' and 'certificate_key' should be specified in the config file")
-		}
-		if _, err := os.Stat(rawConfig.Certificate); errors.Is(err, os.ErrNotExist) {
-			return nil, fmt.Errorf("certificate, '%s', does not exist", rawConfig.Certificate)
-		}
-		if _, err := os.Stat(rawConfig.CertificateKey); errors.Is(err, os.ErrNotExist) {
-			return nil, fmt.Errorf("certificate_key, '%s', does not exist", rawConfig.CertificateKey)
-		}
-		cer_, err := tls.LoadX509KeyPair(rawConfig.Certificate, rawConfig.CertificateKey)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load certificate: %w", err)
-		}
-		cer = &cer_
+	cer, err := loadCertificate(rawConfig.Certificate, rawConfig.CertificateKey, configFileDir)
+	if err != nil {
+		return nil, err
 	}
 
 	logLevelStr := "INFO"
@@ -168,6 +185,7 @@ func parseRawConfig(rawConfig *models.RawConfig) (*proxy.Config, error) {
 		"default_route_proxy", rawConfig.DefaultRoute.Proxy,
 		"default_route_deny_access", rawConfig.DefaultRoute.DenyAccess,
 		"log_level", logLevelStr,
+		"config_dir", configFileDir,
 	)
 	return proxyConfig, nil
 }

--- a/utils/configs/utils_test.go
+++ b/utils/configs/utils_test.go
@@ -1,7 +1,16 @@
 package configs
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/kajikentaro/flexy-proxy/models"
 	"github.com/stretchr/testify/assert"
@@ -14,8 +23,66 @@ func TestAlwaysMitmWithRegex(t *testing.T) {
 		&models.RawConfig{
 			Routes:     []models.RouteConf{{Url: "https://example\\.test", Regex: true}, {Url: "https://foo.test"}},
 			AlwaysMitm: true,
-		})
+		},
+		".",
+	)
 	require.NoError(t, err)
 
 	assert.Empty(t, proxyConfig.HttpsHostNames)
+}
+
+func createTestCert(t *testing.T, certPath, certKeyPath string) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "localhost"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	require.NoError(t, err)
+	certOut := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	keyOut := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)})
+	require.NoError(t, os.WriteFile(certPath, certOut, 0644))
+	require.NoError(t, os.WriteFile(certKeyPath, keyOut, 0644))
+}
+
+func TestLoadCertificateWithRelativePath(t *testing.T) {
+	certName := "cert.pem"
+	certKeyName := "key.pem"
+	tmpDir := t.TempDir()
+	certPath := filepath.Join(tmpDir, certName)
+	certKeyPath := filepath.Join(tmpDir, certKeyName)
+
+	createTestCert(t, certPath, certKeyPath)
+
+	rawConfig := models.RawConfig{
+		Certificate:    certName,
+		CertificateKey: certKeyName,
+	}
+	proxyConfig, err := parseRawConfig(&rawConfig, tmpDir /* directory which has the cert files */)
+	require.NoError(t, err)
+	assert.NotNil(t, proxyConfig.Certificate)
+}
+
+func TestLoadCertificateWithAbsolutePath(t *testing.T) {
+	certName := "cert.pem"
+	certKeyName := "key.pem"
+	tmpDir := t.TempDir()
+	certPath := filepath.Join(tmpDir, certName)
+	certKeyPath := filepath.Join(tmpDir, certKeyName)
+
+	createTestCert(t, certPath, certKeyPath)
+
+	rawConfig := models.RawConfig{
+		Certificate:    certPath,
+		CertificateKey: certKeyPath,
+	}
+	proxyConfig, err := parseRawConfig(&rawConfig, "." /* directory which doesn't have files */)
+	require.NoError(t, err)
+	assert.NotNil(t, proxyConfig.Certificate)
 }


### PR DESCRIPTION
Previously, when we run flexy, `transform` command and `certificate` path are considered from where we execute flexy.
In this PR, I update to use a relative path from the config file (i.e. `config.yaml).

This will be useful when we create a config file with a specific shell script file or certificate file in the same directory.