### PR TITLE
Fix: Read Request body before round tripping

### DIFF
--- a/middlewares/transform.go
+++ b/middlewares/transform.go
@@ -38,11 +38,6 @@ func (t *Transform) Middleware(next http.RoundTripper) http.RoundTripper {
 		// NOTE: if the response body is compressed, we can't use string replacement commands like 'sed'.
 		r.Header.Del("Accept-Encoding")
 
-		res, err := next.RoundTrip(r)
-		if err != nil {
-			return nil, err
-		}
-
 		var reqBody []byte
 		if r.ContentLength > 1024*1024 {
 			reqBody = []byte("BODY env variable is only available for requests with Content-Length less than 1MB")
@@ -58,6 +53,11 @@ func (t *Transform) Middleware(next http.RoundTripper) http.RoundTripper {
 		}
 
 		reqHeader, err := json.Marshal(r.Header)
+		if err != nil {
+			return nil, err
+		}
+
+		res, err := next.RoundTrip(r)
 		if err != nil {
 			return nil, err
 		}

--- a/middlewares/transform_test.go
+++ b/middlewares/transform_test.go
@@ -23,6 +23,10 @@ func (d *dummyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 	res.Header().Set("Content-Type", "text/plain")
 	res.WriteHeader(http.StatusOK)
 	res.Body.Write([]byte(d.resBody))
+	_, err := io.ReadAll(req.Body)
+	if err != nil {
+		panic(err)
+	}
 	return res.Result(), nil
 }
 


### PR DESCRIPTION
When we enable `transform` command and if we have a request body, the below error happens.
```
ERR proxy runtime error: http: invalid Read on closed Body
```
This is the fix for the issue.