### PR TITLE
Feat: Support required_version option

### DIFF
--- a/.github/workflows/build_and_release.yaml
+++ b/.github/workflows/build_and_release.yaml
@@ -27,4 +27,4 @@ jobs:
           compress_assets: OFF
           md5sum: FALSE
           binary_name: "flexy"
-          ldflags: "-X main.version=${{ github.ref_name }}"
+          ldflags: "-X github.com/kajikentaro/flexy-proxy/utils/version.version=${{ github.ref_name }}"

--- a/main.go
+++ b/main.go
@@ -10,20 +10,10 @@ import (
 	"github.com/kajikentaro/flexy-proxy/models"
 	"github.com/kajikentaro/flexy-proxy/proxy"
 	"github.com/kajikentaro/flexy-proxy/utils/configs"
+	"github.com/kajikentaro/flexy-proxy/utils/version"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
-
-// this will be specified like:
-// go build -ldflags "-X 'main.version=1.0.0'"
-var version string
-
-func getVersion() string {
-	if version == "" {
-		return "unknown"
-	}
-	return version
-}
 
 func startProxy(customConfigPath string, portNum int) {
 	proxyConfig, err := configs.ParseConfigFile(customConfigPath)
@@ -86,7 +76,7 @@ func main() {
 		Use:   "version",
 		Short: "Show version",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println(getVersion())
+			fmt.Println(version.GetVersion())
 		},
 	}
 

--- a/models/config-spec.json
+++ b/models/config-spec.json
@@ -5,6 +5,12 @@
   "title": "Flexy Proxy Config Specification",
   "additionalProperties": false,
   "properties": {
+    "required_version": {
+      "type": "string",
+      "default": "",
+      "description": "Minimum required version of Flexy Proxy. If the installed version of Flexy is older than the specified version, Flexy displays a message prompting the user to update it.",
+      "examples": ["v0.2.4"]
+    },
     "default_route": {
       "type": "object",
       "default": {},

--- a/models/models.go
+++ b/models/models.go
@@ -19,6 +19,7 @@ type RawConfig struct {
 	Certificate          string          `yaml:"certificate"`
 	CertificateKey       string          `yaml:"certificate_key"`
 	InsecureCipherSuites bool            `yaml:"insecure_cipher_suites"`
+	RequiredVersion      string          `yaml:"required_version"`
 }
 
 type RawDefaultRoute struct {

--- a/utils/configs/utils.go
+++ b/utils/configs/utils.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kajikentaro/flexy-proxy/proxy"
 	"github.com/kajikentaro/flexy-proxy/routers"
 	"github.com/kajikentaro/flexy-proxy/utils/gethttps"
+	"github.com/kajikentaro/flexy-proxy/utils/version"
 	"github.com/xeipuuv/gojsonschema"
 
 	"gopkg.in/yaml.v3"
@@ -23,6 +24,10 @@ var DEFAULT_CONFIG_PATH = "config.yaml"
 func ParseConfigFile(configPath string) (*proxy.Config, error) {
 	rawConfig, err := ReadConfigYaml(configPath)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := version.VerifyVersion(rawConfig.RequiredVersion, version.GetVersion()); err != nil {
 		return nil, err
 	}
 

--- a/utils/version/version.go
+++ b/utils/version/version.go
@@ -1,0 +1,71 @@
+package version
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// this will be specified like:
+// go build -ldflags "-X $(go list -f '{{.ImportPath}}' ./utils/version).version=v1.0.0"
+var version string
+
+func GetVersion() string {
+	if version == "" {
+		return "unknown"
+	}
+	return version
+}
+
+func VerifyVersion(required string, current string) error {
+	if required == "" || current == "" || current == "unknown" {
+		return nil
+	}
+
+	parseVersion := func(version, name string) ([]int, error) {
+		splitted := strings.Split(version[1:], ".")
+
+		if len(splitted) != 3 || version[:1] != "v" {
+			return nil, fmt.Errorf("format of %s must be \"v[major].[minor].[patch]\"", name)
+		}
+
+		res := make([]int, 3)
+		for i, s := range splitted {
+			num, err := strconv.Atoi(s)
+			if err != nil {
+				return nil, fmt.Errorf("invalid %s \"%s\". failed to parse \"%s\" to int", name, version, s)
+			}
+			res[i] = num
+		}
+
+		return res, nil
+	}
+
+	rNumbers, err := parseVersion(required, "required version")
+	if err != nil {
+		return err
+	}
+	cNumbers, err := parseVersion(current, "build version")
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < 3; i++ {
+		rr := rNumbers[i]
+		cc := cNumbers[i]
+
+		if cc == rr {
+			continue
+		}
+
+		if cc < rr {
+			return fmt.Errorf("Flexy Proxy doesn't support this configuration. Please upgrade Flexy Proxy to %s or later", required)
+		}
+
+		if cc > rr {
+			return nil
+		}
+	}
+
+	return nil
+}

--- a/utils/version/version_test.go
+++ b/utils/version/version_test.go
@@ -1,0 +1,77 @@
+package version
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVerifyVersion(t *testing.T) {
+	cases := []struct {
+		Current      string
+		Required     string
+		ErrorMessage string
+	}{
+		{
+			Current:  "v0.2.0",
+			Required: "v0.1.11",
+		},
+		{
+			Current:  "v0.2.0",
+			Required: "v0.2.0",
+		},
+		{
+			Current:      "v0.2.0",
+			Required:     "v0.2.11",
+			ErrorMessage: "Flexy Proxy doesn't support this configuration. Please upgrade Flexy Proxy to v0.2.11 or later",
+		},
+		{
+			Current: "unknown",
+		},
+		{
+			Current: "v0.2.0",
+		},
+		{
+			Required: "v0.2.0",
+		},
+		{
+			Required:     "0.2.0",
+			Current:      "v0.2.0",
+			ErrorMessage: "format of required version must be \"v[major].[minor].[patch]\"",
+		},
+		{
+			Required:     "v0.2.0",
+			Current:      "0.2.0",
+			ErrorMessage: "format of build version must be \"v[major].[minor].[patch]\"",
+		},
+		{
+			Required:     "v0.2",
+			Current:      "v0.2.0",
+			ErrorMessage: "format of required version must be \"v[major].[minor].[patch]\"",
+		},
+		{
+			Required:     "vX.Y.Z",
+			Current:      "v0.2.0",
+			ErrorMessage: "invalid required version \"vX.Y.Z\". failed to parse \"X\" to int",
+		},
+		{
+			Required:     "v0.2.0",
+			Current:      "vX.Y.Z",
+			ErrorMessage: "invalid build version \"vX.Y.Z\". failed to parse \"X\" to int",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("current: %s, required: %s", c.Current, c.Required), func(t *testing.T) {
+			actual := VerifyVersion(c.Required, c.Current)
+
+			if c.ErrorMessage == "" {
+				assert.Nil(t, actual)
+			} else {
+				assert.Error(t, actual)
+				assert.Equal(t, c.ErrorMessage, actual.Error())
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Use Case**

Some features are available only from a certain version onward.
We want to implicitly specify from which version of Flexy, we can use the config file.

`required_version: 0.2.10` => Flexy need to be v0.2.10 or later.

(NOTE) If user starts Flexy with the version which doesn't support `required_version` option itself, Flexy shows `Additional property required_version is not allowed`.